### PR TITLE
docs: add firmware CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Chess Logger & Clock
 
 [![E2E Tests](https://github.com/anicolao/chess-clock/actions/workflows/e2e.yml/badge.svg)](https://github.com/anicolao/chess-clock/actions/workflows/e2e.yml)
+[![Firmware Unit Tests](https://github.com/anicolao/chess-clock/actions/workflows/firmware-unit-tests.yml/badge.svg)](https://github.com/anicolao/chess-clock/actions/workflows/firmware-unit-tests.yml)
+[![Firmware Emulation Tests](https://github.com/anicolao/chess-clock/actions/workflows/firmware-emulation-tests.yml/badge.svg)](https://github.com/anicolao/chess-clock/actions/workflows/firmware-emulation-tests.yml)
 
 An automatic chess game logger and clock that uses an IP camera to detect moves and advance the clock.
 


### PR DESCRIPTION
## Summary
- Add Firmware Unit Tests and Firmware Emulation Tests badges to README alongside existing E2E badge

## Test plan
- [ ] Verify badges render correctly on PR preview
- [ ] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)