### PR TITLE
feat: add HTTP server component for post-provisioning

### DIFF
--- a/firmware/components/http_server/CMakeLists.txt
+++ b/firmware/components/http_server/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "http_server.c"
+    INCLUDE_DIRS "include"
+    REQUIRES esp_http_server
+)

--- a/firmware/components/http_server/http_server.c
+++ b/firmware/components/http_server/http_server.c
@@ -1,0 +1,69 @@
+#include "http_server.h"
+#include <stdio.h>
+#include <string.h>
+#include <esp_http_server.h>
+#include <esp_log.h>
+
+static const char *TAG = "http_server";
+static httpd_handle_t server = NULL;
+
+static esp_err_t status_handler(httpd_req_t *req) {
+    const char *response = "{\"status\":\"ok\"}";
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_send(req, response, strlen(response));
+    return ESP_OK;
+}
+
+static esp_err_t capture_handler(httpd_req_t *req) {
+    /* Placeholder: will return a JPEG frame from camera_hal */
+    const char *response = "{\"error\":\"not implemented\"}";
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_set_status(req, "501 Not Implemented");
+    httpd_resp_send(req, response, strlen(response));
+    return ESP_OK;
+}
+
+bool http_server_start(void) {
+    if (server != NULL) {
+        ESP_LOGW(TAG, "Server already running");
+        return true;
+    }
+
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+    config.server_port = 80;
+
+    ESP_LOGI(TAG, "Starting HTTP server on port %d", config.server_port);
+    esp_err_t err = httpd_start(&server, &config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to start HTTP server: %s", esp_err_to_name(err));
+        return false;
+    }
+
+    httpd_uri_t status_uri = {
+        .uri = "/api/status",
+        .method = HTTP_GET,
+        .handler = status_handler,
+    };
+    httpd_register_uri_handler(server, &status_uri);
+
+    httpd_uri_t capture_uri = {
+        .uri = "/capture",
+        .method = HTTP_GET,
+        .handler = capture_handler,
+    };
+    httpd_register_uri_handler(server, &capture_uri);
+
+    printf("HTTP server started on port 80\n");
+    printf("Registered endpoints: /api/status, /capture\n");
+    return true;
+}
+
+void http_server_stop(void) {
+    if (server != NULL) {
+        httpd_stop(server);
+        server = NULL;
+        ESP_LOGI(TAG, "HTTP server stopped");
+    }
+}

--- a/firmware/components/http_server/include/http_server.h
+++ b/firmware/components/http_server/include/http_server.h
@@ -1,0 +1,18 @@
+#ifndef HTTP_SERVER_H
+#define HTTP_SERVER_H
+
+#include <stdbool.h>
+
+/**
+ * Start the HTTP server after provisioning completes.
+ * Registers /api/status and /capture endpoints.
+ * Returns true on success, false on failure.
+ */
+bool http_server_start(void);
+
+/**
+ * Stop the HTTP server.
+ */
+void http_server_stop(void);
+
+#endif // HTTP_SERVER_H

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,2 +1,4 @@
 idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS ".")
+                    INCLUDE_DIRS "."
+                    REQUIRES http_server
+                    PRIV_REQUIRES camera_hal provisioning esp_netif esp_event)

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -1,10 +1,14 @@
 #include <stdio.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_netif.h"
+#include "esp_event.h"
 #include "camera_hal.h"
 #include "provisioning.h"
+#include "http_server.h"
 
 prov_ctx_t prov_ctx;
+static bool server_started = false;
 
 bool wifi_connect_mock(const char *ssid, const char *password) {
     printf("Connecting to Wi-Fi SSID: %s\n", ssid);
@@ -24,6 +28,9 @@ bool mdns_announce_mock(void) {
 void app_main(void)
 {
     printf("ESP32S3 initialization complete.\n");
+
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
 
     prov_init(&prov_ctx);
     prov_set_wifi_connect_cb(&prov_ctx, wifi_connect_mock);
@@ -53,7 +60,14 @@ void app_main(void)
                 printf("Failed to acquire frame\n");
             }
         } else {
-            printf("Device is provisioned. Idling...\n");
+            if (!server_started) {
+                printf("Device is provisioned. Starting HTTP server...\n");
+                if (http_server_start()) {
+                    server_started = true;
+                } else {
+                    printf("Failed to start HTTP server, will retry...\n");
+                }
+            }
         }
         vTaskDelay(2000 / portTICK_PERIOD_MS);
     }

--- a/firmware/test_app.py
+++ b/firmware/test_app.py
@@ -10,4 +10,6 @@ def test_provisioning_flow(dut: IdfDut):
     dut.expect("Announcing via mDNS...", timeout=5)
     dut.expect("QR code decoded successfully!", timeout=5)
     dut.expect("Transitioned to PROV_STATE_PROVISIONED", timeout=5)
-    dut.expect("Device is provisioned. Idling...", timeout=5)
+    dut.expect("Device is provisioned. Starting HTTP server...", timeout=5)
+    dut.expect("HTTP server started on port 80", timeout=5)
+    dut.expect("Registered endpoints: /api/status, /capture", timeout=5)


### PR DESCRIPTION
## Summary
- Adds `firmware/components/http_server/` wrapping ESP-IDF's `esp_http_server` with `/api/status` and `/capture` endpoints
- After QR provisioning completes, `main.c` initializes the TCP/IP stack and starts the HTTP server automatically
- Updates QEMU emulation test to verify the server starts successfully after provisioning

## Test plan
- [x] ESP-IDF build passes locally
- [x] QEMU emulation test passes (provisioning flow + HTTP server startup)
- [x] Host unit tests pass (11/11 — http_server is ESP-IDF-only, not in host build)
- [x] E2E tests pass locally
- [ ] CI firmware-emulation-tests pass
- [ ] CI firmware-unit-tests pass
- [ ] CI e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)